### PR TITLE
Skip application page fields with empty names

### DIFF
--- a/scraperlib/local_knowledge.py
+++ b/scraperlib/local_knowledge.py
@@ -100,8 +100,15 @@ def extract_application_details(application_url):
 
     result = {}
     for display_name, value in fields.items():
-        display_name = display_name.strip()
+        display_name = display_name.strip() if display_name else None
         value = value.strip() if value else None
+
+        if not display_name:
+            # NOTE: Some fields contain links as their "name", which
+            #   means that the td[1] we hunted for earlier gives us None.
+            #   Those fields aren't the ones we're trying to scrape anyway,
+            #   so... skip.
+            continue
 
         field_name = display_map.get(display_name)
         if field_name:


### PR DESCRIPTION
Hi folks,

Coming up for air and finally looking into why the noosa scraper was choking periodically.

Details about problem and fix [logged here](https://github.com/otherchirps/noosa_council/issues/3).
Now successfully completes in [my instance of the scraper](https://morph.io/otherchirps/noosa_council).

Pretty minor change, but if you've thoughts on anything you'd like changed before merging, let me know.
